### PR TITLE
Clearing systems

### DIFF
--- a/bank.go
+++ b/bank.go
@@ -17,15 +17,15 @@ type Institution struct {
 }
 
 type Branch struct {
-	BSB      BSB             `json:"bsb,omitempty"`
-	Name     string          `json:"name,omitempty"`
-	Bank     Institution     `json:"bank,omitempty"`
-	BankCode string          `json:"bank_code,omitempty"`
-	Address  string          `json:"address,omitempty"`
-	Suburb   string          `json:"suburb,omitempty"`
-	State    string          `json:"state,omitempty"`
-	Postcode string          `json:"postcode,omitempty"`
-	Payments ClearingSystems `json:"payments,omitempty"`
+	BSB           BSB             `json:"bsb,omitempty"`
+	Name          string          `json:"name,omitempty"`
+	Bank          Institution     `json:"bank,omitempty"`
+	BankCode      string          `json:"bank_code,omitempty"`
+	Address       string          `json:"address,omitempty"`
+	Suburb        string          `json:"suburb,omitempty"`
+	State         string          `json:"state,omitempty"`
+	Postcode      string          `json:"postcode,omitempty"`
+	PaymentsFlags ClearingSystems `json:"payments_flags,omitempty"`
 }
 
 func init() {

--- a/bank.go
+++ b/bank.go
@@ -17,14 +17,15 @@ type Institution struct {
 }
 
 type Branch struct {
-	BSB      BSB         `json:"bsb,omitempty"`
-	Name     string      `json:"name,omitempty"`
-	Bank     Institution `json:"bank,omitempty"`
-	BankCode string      `json:"bank_code,omitempty"`
-	Address  string      `json:"address,omitempty"`
-	Suburb   string      `json:"suburb,omitempty"`
-	State    string      `json:"state,omitempty"`
-	Postcode string      `json:"postcode,omitempty"`
+	BSB      BSB             `json:"bsb,omitempty"`
+	Name     string          `json:"name,omitempty"`
+	Bank     Institution     `json:"bank,omitempty"`
+	BankCode string          `json:"bank_code,omitempty"`
+	Address  string          `json:"address,omitempty"`
+	Suburb   string          `json:"suburb,omitempty"`
+	State    string          `json:"state,omitempty"`
+	Postcode string          `json:"postcode,omitempty"`
+	Payments ClearingSystems `json:"payments,omitempty"`
 }
 
 func init() {

--- a/bsb_test.go
+++ b/bsb_test.go
@@ -87,12 +87,12 @@ func TestDate_MarshalJSON(t *testing.T) {
 	}{
 		{
 			name: "123-456",
-			bsb:  MustBSB("123-456"),
+			bsb:  BSB(123456),
 			want: "\"123-456\"",
 		},
 		{
 			name: "012-345",
-			bsb:  MustBSB("012-345"),
+			bsb:  BSB(12345),
 			want: "\"012-345\"",
 		},
 	}

--- a/clearingsystems.go
+++ b/clearingsystems.go
@@ -1,0 +1,83 @@
+package bank
+
+import (
+	"encoding/json"
+)
+
+// The payments flags refer to the clearing systems (frameworks) with P=Paper (APCS), E=Electronic (IAC) and H=High Value (HVCS).
+type ClearingSystems byte
+
+// ClosedClearingSystem is closed
+const ClosedClearingSystem ClearingSystems = 0
+
+const (
+	PaperClearing      = 1 << iota // P=Paper (APCS)
+	ElectronicClearing             // E=Electronic (IAC)
+	HighValueClearing              // H=High Value (HVCS)
+)
+
+// NewClearingSystems parses the list of flags into a ClearingSystems type.
+// The ClearingsSystem contains all the avaliable clearing systems.
+// If no flags are providedd a Closed clearing system is returned.
+func NewClearingSystems(flags string) ClearingSystems {
+	var cs ClearingSystems
+	for _, f := range flags {
+		switch f {
+		case 'P', 'p':
+			cs |= PaperClearing
+		case 'E', 'e':
+			cs |= ElectronicClearing
+		case 'H', 'h':
+			cs |= HighValueClearing
+		}
+	}
+	return cs
+}
+
+// Closed returns true is the clearing system is closed
+func (cs ClearingSystems) Closed() bool { return cs == ClosedClearingSystem }
+
+// Paper returns true if Paper clearing system (APCS) is avaliable
+func (cs ClearingSystems) Paper() bool { return cs&PaperClearing == PaperClearing }
+
+// Electronic returns true if Electronic clearing system (IAC) is avaliable
+func (cs ClearingSystems) Electronic() bool { return cs&ElectronicClearing == ElectronicClearing }
+
+// HighValue returns true if HighValue clearing system (HVCS) is avaliable
+func (cs ClearingSystems) HighValue() bool { return cs&HighValueClearing == HighValueClearing }
+
+// String returns a list of the avaliable clearing systems.
+// P=Paper (APCS), E=Electronic (IAC) and H=High Value (HVCS).
+// An empty string is returned if closed.
+func (cs ClearingSystems) String() string {
+	if cs.Closed() {
+		return ""
+	}
+	var str string
+	if cs.Paper() {
+		str += "P"
+	}
+	if cs.Electronic() {
+		str += "E"
+	}
+	if cs.HighValue() {
+		str += "H"
+	}
+	return str
+}
+
+// MarshalJSON marshals the ClearingSystems into JSON format.
+func (cs ClearingSystems) MarshalJSON() ([]byte, error) {
+	return json.Marshal(cs.String())
+}
+
+// MarshalJSON unmarshal's JSON into a ClearingSystems type.
+func (cs *ClearingSystems) UnmarshalJSON(data []byte) error {
+	var j string
+	err := json.Unmarshal(data, &j)
+	if err != nil {
+		return err
+	}
+	*cs = NewClearingSystems(j)
+	return nil
+}

--- a/clearingsystems.go
+++ b/clearingsystems.go
@@ -18,7 +18,7 @@ const (
 
 // NewClearingSystems parses the list of flags into a ClearingSystems type.
 // The ClearingsSystem contains all the avaliable clearing systems.
-// If no flags are providedd a Closed clearing system is returned.
+// If no flags are provided a Closed clearing system is returned.
 func NewClearingSystems(flags string) ClearingSystems {
 	var cs ClearingSystems
 	for _, f := range flags {

--- a/clearingsystems_test.go
+++ b/clearingsystems_test.go
@@ -1,0 +1,128 @@
+package bank
+
+import (
+	"testing"
+)
+
+func TestNewClearingSystems(t *testing.T) {
+	tests := []struct {
+		flags string
+		want  ClearingSystems
+	}{
+		// P, PE, PEH, E, EH or blank if closed
+		{"", ClosedClearingSystem},
+		{"P", PaperClearing},
+		{"PE", PaperClearing | ElectronicClearing},
+		{"PEH", PaperClearing | ElectronicClearing | HighValueClearing},
+		{"E", ElectronicClearing},
+		{"EH", ElectronicClearing | HighValueClearing},
+		{"P,E,H", PaperClearing | ElectronicClearing | HighValueClearing},
+		{"p,e,h", PaperClearing | ElectronicClearing | HighValueClearing},
+	}
+	for _, tt := range tests {
+		t.Run(tt.flags, func(t *testing.T) {
+			if got := NewClearingSystems(tt.flags); got != tt.want {
+				t.Errorf("NewClearingSystems() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClearingSystems_String(t *testing.T) {
+	tests := []struct {
+		cs   ClearingSystems
+		want string
+	}{
+		// P, PE, PEH, E, EH or blank if closed
+		{ClosedClearingSystem, ""},
+		{ClearingSystems(PaperClearing), "P"},
+		{ClearingSystems(PaperClearing | ElectronicClearing), "PE"},
+		{ClearingSystems(PaperClearing | ElectronicClearing | HighValueClearing), "PEH"},
+		{ClearingSystems(ElectronicClearing), "E"},
+		{ClearingSystems(ElectronicClearing | HighValueClearing), "EH"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.cs.String(); got != tt.want {
+				t.Errorf("ClearingSystems.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClearingSystems_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		cs      ClearingSystems
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "P,E,H",
+			cs:   ClearingSystems(PaperClearing | ElectronicClearing | HighValueClearing),
+			want: "\"PEH\"",
+		},
+		{
+			name: "Closed",
+			cs:   ClosedClearingSystem,
+			want: "\"\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.cs.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ClearingSystems.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if string(got) != tt.want {
+				t.Errorf("ClearingSystems.MarshalJSON() = %v, want %v", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestClearingSystems_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   string
+		want    ClearingSystems
+		wantErr bool
+	}{
+		{
+			name:  "P,E,H",
+			flags: "\"P,E,H\"",
+			want:  ClearingSystems(PaperClearing | ElectronicClearing | HighValueClearing),
+		},
+		{
+			name:  "PEH",
+			flags: "\"PEH\"",
+			want:  ClearingSystems(PaperClearing | ElectronicClearing | HighValueClearing),
+		},
+		{
+			name:    "string error",
+			flags:   "\"abc",
+			want:    ClosedClearingSystem,
+			wantErr: true,
+		},
+		{
+			name:    "Closed",
+			flags:   "",
+			want:    ClosedClearingSystem,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			var got ClearingSystems
+			err := got.UnmarshalJSON([]byte(tt.flags))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ClearingSystems.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ClearingSystems.UnmarshalJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/clearingsystems_test.go
+++ b/clearingsystems_test.go
@@ -16,6 +16,7 @@ func TestNewClearingSystems(t *testing.T) {
 		{"PEH", PaperClearing | ElectronicClearing | HighValueClearing},
 		{"E", ElectronicClearing},
 		{"EH", ElectronicClearing | HighValueClearing},
+		{"P H", PaperClearing | HighValueClearing},
 		{"P,E,H", PaperClearing | ElectronicClearing | HighValueClearing},
 		{"p,e,h", PaperClearing | ElectronicClearing | HighValueClearing},
 	}

--- a/cmd/bsblookup/main.go
+++ b/cmd/bsblookup/main.go
@@ -37,7 +37,7 @@ func printStandard(branch bank.Branch) {
 	fmt.Printf("BANK_NAME=%q\n", branch.Bank.Name)
 	fmt.Printf("BRANCH_NAME=%q\n", branch.Name)
 	fmt.Printf("BRANCH_ADDRESS=%q\n", branch.Address+" "+branch.Suburb+" "+branch.State+" "+branch.Postcode)
-	fmt.Printf("BRANCH_PAYMENTS=%q\n", branch.Payments.String())
+	fmt.Printf("BRANCH_PAYMENTS=%q\n", branch.PaymentsFlags.String())
 }
 
 func printJSON(branch bank.Branch) {

--- a/cmd/bsblookup/main.go
+++ b/cmd/bsblookup/main.go
@@ -37,6 +37,7 @@ func printStandard(branch bank.Branch) {
 	fmt.Printf("BANK_NAME=%q\n", branch.Bank.Name)
 	fmt.Printf("BRANCH_NAME=%q\n", branch.Name)
 	fmt.Printf("BRANCH_ADDRESS=%q\n", branch.Address+" "+branch.Suburb+" "+branch.State+" "+branch.Postcode)
+	fmt.Printf("BRANCH_PAYMENTS=%q\n", branch.Payments.String())
 }
 
 func printJSON(branch bank.Branch) {

--- a/data.go
+++ b/data.go
@@ -65,6 +65,7 @@ func loadData() map[BSB]Branch {
 			Suburb:   rec[4],
 			State:    rec[5],
 			Postcode: rec[6],
+			Payments: NewClearingSystems(rec[7]),
 		}
 	}
 

--- a/data.go
+++ b/data.go
@@ -57,15 +57,15 @@ func loadData() map[BSB]Branch {
 		}
 		bank := matchInstitution(bsb, rec[1], institutionLookup[rec[1]], allInstitutions)
 		bsbLookup[bsb] = Branch{
-			BSB:      bsb,
-			Name:     rec[2],
-			Bank:     bank,
-			BankCode: rec[1],
-			Address:  rec[3],
-			Suburb:   rec[4],
-			State:    rec[5],
-			Postcode: rec[6],
-			Payments: NewClearingSystems(rec[7]),
+			BSB:           bsb,
+			Name:          rec[2],
+			Bank:          bank,
+			BankCode:      rec[1],
+			Address:       rec[3],
+			Suburb:        rec[4],
+			State:         rec[5],
+			Postcode:      rec[6],
+			PaymentsFlags: NewClearingSystems(rec[7]),
 		}
 	}
 


### PR DESCRIPTION
## Add Payments Flags

- BSB Payments Flags (P, PE, PEH, E, EH or blank if closed).

The payments flags refer to the clearing systems (frameworks) with P=Paper (APCS), E=Electronic (IAC) and H=High Value (HVCS).

Sample CSV Line (not real data)
```
"123-456","ABC","XYZ Company","109 Test Street","Sydney","NSW","2000","PEH"
```

**Reference Doc:**
https://bsb.auspaynet.com.au/public/BSB_DB.NSF/0/72E7EB6B4734232ECA2579650017682D/$File/Downloading%20BSB%20Files%20from%20AusPayNet%20via%20FTP.pdf